### PR TITLE
Fixed path for schema_dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ ring file: "no such file or directory"`. We need to add some configuration to
   [{ring_state_dir, "./data/ring"},
    {web_port, 8098},
    {handoff_port, 8099},
-   {schema_dirs, ["priv"]}
+   {schema_dirs, ["lib/rc_example-0.1.0/priv"]}
   ]}].
 ```
 


### PR DESCRIPTION
The tutorial fails currently at running the release, the `riak_core` schema file cannot be found.

It seems rebar3 copies/links the `priv` folder only in the `lib` folder, not in the `rel` folder, where it gets entirely ignored. 

The `sys.config` file in the repository is different from the tutorial readme, so the path should be adjusted for the tutorial to work properly.